### PR TITLE
Add a third motivating example and anti-gender discrimination discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ line-length = 79
 
 ## Why does this need to exist?
 
-- The current maintainer of black, [refuses](https://github.com/psf/black/pull/633#issuecomment-445477386) to allow a single-quotes option. Due to his own *personal* preference (a preference which most of the Python community do not share).
+- The current maintainer of Black, [refuses](https://github.com/psf/black/pull/633#issuecomment-445477386) to allow a single-quotes option. Due to his own *personal* preference (a preference which most of the Python community do not share).
 
-- The current maintainer of black, [refuses](https://github.com/psf/black/issues/683#issuecomment-542731068) to add setup.cfg support. Setup.cfg is the most widely used configuration file for Python projects. The maintainer of that library prefers "project.tolm" few people use at this time due to it's inflexibility and it requiring you to use Poetry, whatever that is.
+- The current maintainer of Black, [refuses](https://github.com/psf/black/issues/683#issuecomment-542731068) to add setup.cfg support. Setup.cfg is the most widely used configuration file for Python projects. The maintainer of that library prefers "project.tolm" few people use at this time due to it's inflexibility and it requiring you to use Poetry, whatever that is.
 
 - The current configuration file format as adopted by Black may conflict with the new _build isolation_ context with `pip`.  To avoid this, the use of a `setup.cfg` file is preferred but the policy is under review by the maintainers (https://github.com/pypa/pip/issues/8437#issuecomment-644196428).
 
@@ -113,5 +113,5 @@ repos:
 
 ## A word on gender identity and appropriate naming conversions
 
-The words 'blond', 'brunette', 'black', `red-head`, etc. are _generally_ used as shorthands for individuals who identify as female and have specific colors of head hair.  The term `brunette` _generally_ stands for a woman with deep brown hair.  The term for this tool `brunette` is meant to be wordplay on `black`, the original tool that this fork is based on.  The use of that term (and the hair-color motif that is employed) is not intended, in any way, to be derogatory or misogynistic.  We would like to re-purpose the term `brunette` with a neutral connotation in this tool, but, if that assumption is misguided or misplaced, please let us know in a GitHub issue.
+The words `blond`, `brunette`, `black`, `red-head`, etc. are _generally_ used as shorthands for individuals who identify as female and have specific colors of head hair.  The term `brunette` _generally_ stands for a woman with deep brown hair.  The name for this tool `Brunette` is meant to be wordplay on `Black`, the original tool that this fork is based on.  The use of that term (and the hair-color motif that is employed) is not intended, in any way, to be derogatory or misogynistic.  We would like to re-purpose the term `brunette` as this tool's name with a completely neutral connotation, but, if that assumption is misguided or misplaced, please let us know in a GitHub issue.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,26 @@ Example `setup.cfg`:
 line-length = 79
 verbose = true
 single-quotes = false
-# etc, etc.
+# etc, etc...
+```
+
+This can also be combined with Flake8's configuration:
+
+```
+[flake8]
+# This section configures `flake8`, the python linting utility.
+# See also https://flake8.pycqa.org/en/latest/user/configuration.html
+ignore = E201,E202,E203
+# E201 - whitespace after ‘(‘
+# E202 - whitespace before ‘)’
+# E203 - whitespace before ‘:’
+
+# Exclude the git directory and virtualenv directory (as `.env`)
+exclude = .git,.env
+
+[tool:brunette]
+line-length = 79
+# etc, etc...
 ```
 
 ## Why does this need to exist?
@@ -39,7 +58,7 @@ single-quotes = false
 
 - The current maintainer of black, [refuses](https://github.com/psf/black/issues/683#issuecomment-542731068) to add setup.cfg support. Setup.cfg is the most widely used configuration file for Python projects. The maintainer of that library prefers "project.tolm" few people use at this time due to it's inflexibility and it requiring you to use Poetry, whatever that is.
 
-
+- The current configuration file format as adopted by Black may conflict with the new _build isolation_ context with `pip`.  To avoid this, the use of a `setup.cfg` file is preferred but the policy is under review by the maintainers (https://github.com/pypa/pip/issues/8437#issuecomment-644196428).
 
 ## How to configure in VSCode
 
@@ -57,3 +76,42 @@ In my case this looks like `/home/work/.pyenv/shims/brunette`. Now copy whatever
 ![https://i.imgur.com/6EXoamM.png](https://i.imgur.com/6EXoamM.png)
 
 3. That's it! Now whenever you [format your Python code](https://stackoverflow.com/a/48764668/13405802) brunette will be used.
+
+## How to configure with Pre-Commit (https://pre-commit.com)
+
+1. Run `pip install pre-commit` to install 
+
+2. Add a local repo option for brunette in `.pre-commit-config.yaml`
+
+```
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: local
+    hooks:
+      - id: brunette
+        name: brunette
+        description: Run Brunette on Python code (fork of Black).
+        entry: brunette --config=setup.cfg
+        language: system
+        types: [python]
+  # Drop-in replacement for black with brunette
+  # - repo: https://github.com/psf/black
+  #   rev: stable
+  #   hooks:
+  #     - id: black
+  #       language_version: python3.6
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.1
+    hooks:
+      - id: flake8
+```
+
+3. Run `pre-commit install` to install the Git pre-commit hook
+
+3. Run `pre-commit run` to validate all files
+
+## A word on gender identity and appropriate naming conversions
+
+The words 'blond', 'brunette', 'black', `red-head`, etc. are _generally_ used as shorthands for individuals who identify as female and have specific colors of head hair.  The term `brunette` _generally_ stands for a woman with deep brown hair.  The term for this tool `brunette` is meant to be wordplay on `black`, the original tool that this fork is based on.  The use of that term (and the hair-color motif that is employed) is not intended, in any way, to be derogatory or misogynistic.  We would like to re-purpose the term `brunette` with a neutral connotation in this tool, but, if that assumption is misguided or misplaced, please let us know in a GitHub issue.
+

--- a/README.md
+++ b/README.md
@@ -110,8 +110,3 @@ repos:
 3. Run `pre-commit install` to install the Git pre-commit hook
 
 3. Run `pre-commit run` to validate all files
-
-## A word on gender identity and appropriate naming conversions
-
-The words `blond`, `brunette`, `black`, `red-head`, etc. are _generally_ used as shorthands for individuals who identify as female and have specific colors of head hair.  The term `brunette` _generally_ stands for a woman with deep brown hair.  The name for this tool `Brunette` is meant to be wordplay on `Black`, the original tool that this fork is based on.  The use of that term (and the hair-color motif that is employed) is not intended, in any way, to be derogatory or misogynistic.  We would like to re-purpose the term `brunette` as this tool's name with a completely neutral connotation, but, if that assumption is misguided or misplaced, please let us know in a GitHub issue.
-


### PR DESCRIPTION
The maintainers of `pip` have been working behind the scenes (https://github.com/pypa/pip/issues/8437#issuecomment-644196428) to add build isolation configurations to newer versions.  This uses a `project.toml` file to ensure configuration information is provided in a scripted way, but was co-opted by the developers of Flake8 and Black before it could realistically be used for pip-only applications.  As a result, if a `project.toml` file exists in a repository for the purposes of configuring `Black` it will force pip to use the more locked down build process and will cause various issues like import failures in setup.py.  The natural solution is to move to the most standardized `setup.cfg` file for Black, but the maintainers refused to allow this option.  Luckily, your project allows exactly this feature.  I've added a third motivating example to your list to highlight this issue and provide a more direct link for people who are looking to jump ship from Black's stubbornness.

I've also added a description on how to do a drop-in-replacement from Black to Brunette as used by pre-commit.  

Finally, I had a developer friend comment on the somewhat sensitive/risky naming convention by using the term brunette.  I'm sure that this was an innocent play on words, but explaining that explicitly in the READMe with an added anti-gender-discrimination discussion may help to reassure collaborators.