### PR TITLE
Force serial formatting of files

### DIFF
--- a/brunette/brunette.py
+++ b/brunette/brunette.py
@@ -139,9 +139,20 @@ def read_config_file(ctx, param, value):
 
 
 BLACK_MAIN = black.main
+BLACK_REFORMAT_MANY = black.reformat_many
+
+
+def reformat_many(sources, *args, **kwargs):
+    """Monkeypatched to reformat multiple files using ``black.reformat_one``."""
+    for src in sources:
+        black.reformat_one(src, *args, **kwargs)
 
 
 def main():
+    # Monkeypatch the execution of many files, which uses a process execution
+    # manager that paves over this project's patching of the string normalizer
+    black.reformat_many = reformat_many
+
     config_file_opt = [p for p in BLACK_MAIN.params if p.name == 'config'][0]
     config_file_opt.callback = read_config_file
     options = [p for p in BLACK_MAIN.params if p.name != 'config']


### PR DESCRIPTION
Because `black.reformat_many` uses a `ProcessPoolExecutor`, the patch
to the string normalizer in brunette is nullified. This bit of code
forces black to process the files in serial using the
`black.reformat_one`, which is it's default action when given a single
file for processing.

I don't expect this to be accepted, as it's it would force everyone using the tool into a serial execution path, which doesn't seem to be something everyone is experiencing. I'm more or less submitting it, because it works for me, could be useful as a starting place for a better fix and is maybe useful to others.

Fixes #5 