### PR TITLE
loosen pin on black version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,5 @@ mccabe==0.6.1
 zest.releaser==6.20.1
 ipdb==0.13.2
 tox==3.15.0
+# Version pin here, providing consistent formatting for brunette code
+black==20.8b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools
 wheel
-black==20.8b1
+# Do not pin this one, leave black version up to user
+black>=19.10b0
 click

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,13 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 with open('requirements.txt') as f:
     install_requires = f.read().splitlines()
 
+with open('requirements-dev.txt') as f:
+    dev_install_requires = [
+        l
+        for l in f.read().splitlines()
+        if not (l.startswith('-r') or l.startswith('#'))
+    ]
+
 with open('README.md', 'r', encoding='utf-8') as rm_file:
     readme = rm_file.read()
 
@@ -32,6 +39,7 @@ setup(
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/markdown',
     install_requires=install_requires,
+    extras_require={'dev': dev_install_requires},
     classifiers=[
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',


### PR DESCRIPTION
See issue #15. When brunette is installed as a tool, it should allow user to choose the version of black.

Instead, pin to specific version only for 'dev' mode when maintaining 'brunette'.