### PR TITLE
Pass a valid string to path_empty

### DIFF
--- a/brunette/brunette.py
+++ b/brunette/brunette.py
@@ -443,7 +443,13 @@ def main(
     if isinstance(root, tuple):
         root = root[0]
     sources: Set[Path] = set()
-    path_empty(src=src, quiet=quiet, verbose=verbose, ctx=ctx, msg=None)
+    path_empty(
+        src=src,
+        quiet=quiet,
+        verbose=verbose,
+        ctx=ctx,
+        msg="No Path provided. Nothing to do 😴",
+    )
     for s in src:
         p = Path(s)
         if p.is_dir():


### PR DESCRIPTION
From black v22.1.0 type checking is "baked in" at runtime due to the use
of mypyc. This causes a TypeError when calling path_empty, which passes
"msg=None", where a str is expected instead. To fix this behaviour, it's
easy enough to pass the same string that black itself is currently using
(see [1]).

[1]: https://github.com/psf/black/blob/f1d4e742c91dd5179d742b0db9293c4472b765f8/src/black/__init__.py#L521